### PR TITLE
Refactor header and footer into reusable partials

### DIFF
--- a/CliniCare/Guest/medicine/MedicineCatalogueGuest.php
+++ b/CliniCare/Guest/medicine/MedicineCatalogueGuest.php
@@ -1,80 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-  <meta charset="utf-8">
-  <meta content="width=device-width, initial-scale=1.0" name="viewport">
-
-  <title>Welcome | CliniCare</title>
-  <meta content="" name="description">
-  <meta content="" name="keywords">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="bootstrap.css">
-
-  <!-- Favicons -->
-  <link href="../../assets/img/gambar/icon.jpeg" rel="icon">
-  <link href="../../assets/img/gambar/icon.jpeg" rel="apple-touch-icon">
-
-  <!-- Google Fonts -->
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
-
-  <!-- Vendor CSS Files -->
-  <link href="../../assets/vendor/animate.css/animate.min.css" rel="stylesheet">
-  <link href="../../assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-  <link href="../../assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
-  <link href="../../assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
-  <link href="../../assets/vendor/fontawesome-free/css/all.min.css" rel="stylesheet">
-  <link href="../../assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
-  <link href="../../assets/vendor/remixicon/remixicon.css" rel="stylesheet">
-  <link href="../../assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
-  <script src="https://code.iconify.design/2/2.0.3/iconify.min.js"></script>
-
-  <!-- Template Main CSS File -->
-  <link href="../../assets/css/style.css" rel="stylesheet">
-
-</head>
-
-<body>
-
-  <!-- ======= Top Bar ======= -->
-  <div id="topbar" class="d-flex align-items-center fixed-top">
-    <div class="container d-flex justify-content-between">
-      <div class="contact-info d-flex align-items-center">
-        <i class="bi bi-envelope"></i> <a href="mailto:info@clinicare.com.my">info@clinicare.com.my</a>
-        <i class="bi bi-phone"></i> 03-3289 6079
-      </div>
-      <div class="d-none d-lg-flex social-links align-items-center">
-        <a href="https://twitter.com/klinikdamai?s=20" class="twitter"><i class="bi bi-twitter"></i></a>
-        <a href="https://www.facebook.com/klinikdamaikualaselangor24jam/" class="facebook"><i class="bi bi-facebook"></i></a>
-        <a href="https://www.instagram.com/klinikdamaikualaselangor24jam/" class="instagram"><i class="bi bi-instagram"></i></a>
-      </div>
-    </div>
-  </div>
-
-  <!-- ======= Header ======= -->
-  <header id="header" class="fixed-top">
-    <div class="container d-flex align-items-center">
-
-      <!-- Uncomment below if you prefer to use an image logo -->
-      <a href="../../index.php" class="logo me-auto"><img src="../../assets/img/gambar/logobanner.png" alt="" class="img-fluid"></a>
-
-      <nav id="navbar" class="navbar order-last order-lg-0">
-        <ul>
-          <li><a class="nav-link scrollto" href="../../index.php">Home</a></li>
-          <li><a class="nav-link scrollto" href="../../index.php">About</a></li>
-          <li><a class="nav-link scrollto" href="../../index.php">Services</a></li>
-          <li><a class="nav-link scrollto" href="../../index.php">Doctors</a></li>
-          <li><a class="nav-link scrollto" href="../../index.php">FAQ</a></li>
-          <li><a class="nav-link scrollto" href="../../index.php">Contact Us</a></li>
-          <li><a class="nav-link scrollto active" href="../medicine/MedicineCatalogueGuest.php">Medicine</a></li>
-        </ul>
-        <i class="bi bi-list mobile-nav-toggle"></i>
-      </nav><!-- .navbar -->
-
-      <a href="../../Customer/Sign In Page/Sign In/signin.php"><button class="appointment-btn scrollto">Sign In / Sign Up</button></a>
-    </div>
-  </header><!-- End Header -->
-
+<?php
+$basePath = '../../';
+require __DIR__ . '/../../app/Views/partials/header.php';
+?>
   <!-- ======= Hero Section ======= -->
   <section id="hero" class="d-flex align-items-center">
     <div class="container">
@@ -251,40 +178,7 @@
     </section><!-- End Why Us Section -->
 
   </main><!-- End #main -->
-
-  <!-- ======= Footer ======= -->
-  <footer id="footer">
-
-
-    <div class="container d-md-flex py-4">
-
-      <div class="me-md-auto text-center text-md-start">
-        <div class="copyright">
-          &copy; Copyright <strong><span>C L I N I C A R E</span></strong>. All Rights Reserved
-        </div>
-
-      </div>
-      <div class="social-links text-center text-md-right pt-3 pt-md-0">
-        <a href="https://twitter.com/klinikdamai?s=20" class="twitter"><i class="bx bxl-twitter"></i></a>
-        <a href="https://www.facebook.com/klinikdamaikualaselangor24jam/" class="facebook"><i class="bx bxl-facebook"></i></a>
-        <a href="https://www.instagram.com/klinikdamaikualaselangor24jam/" class="instagram"><i class="bx bxl-instagram"></i></a>
-      </div>
-    </div>
-  </footer><!-- End Footer -->
-
-  <div id="preloader"></div>
-  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
-
-  <!-- Vendor JS Files -->
-  <script src="../../assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="../../assets/vendor/glightbox/js/glightbox.min.js"></script>
-  <script src="../../assets/vendor/php-email-form/validate.js"></script>
-  <script src="../../assets/vendor/purecounter/purecounter.js"></script>
-  <script src="../../assets/vendor/swiper/swiper-bundle.min.js"></script>
-
-  <!-- Template Main JS File -->
-  <script src="../../assets/js/main.js"></script>
-
-</body>
-
-</html>
+<?php
+$basePath = '../../';
+require __DIR__ . '/../../app/Views/partials/footer.php';
+?>

--- a/CliniCare/app/Views/partials/footer.php
+++ b/CliniCare/app/Views/partials/footer.php
@@ -1,0 +1,81 @@
+<?php
+if (!isset($basePath)) {
+    $basePath = '';
+}
+?>
+  <!-- ======= Footer ======= -->
+  <footer id="footer">
+
+    <div class="footer-top">
+      <div class="container">
+        <div class="row">
+
+          <div class="col-lg-3 col-md-6 footer-contact">
+            <h3>C L I N I C A R E</h3>
+            <p>
+              No. 43 & 45, Jalan Melati 3/17, Bandar Melawati,<br>
+              45000 Kuala Selangor,<br>
+              Selangor<br><br>
+              <strong>Phone:</strong> 03-3289 6079<br>
+              <strong>Email:</strong> info@clinicare.com<br>
+            </p>
+          </div>
+
+          <div class="col-lg-2 col-md-6 footer-links">
+            <h4>Useful Links</h4>
+            <ul>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Home</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">About us</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Services</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Terms of service</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Privacy policy</a></li>
+            </ul>
+          </div>
+
+          <div class="col-lg-3 col-md-6 footer-links">
+            <h4>Our Services</h4>
+            <ul>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Pharmacy</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Primary Care</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Mom & Baby Care</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Medical Check-Up</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Swab Test Covid-19</a></li>
+              <li><i class="bx bx-chevron-right"></i> <a href="#">Smoking Cessation Campaign</a></li>
+            </ul>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="container d-md-flex py-4">
+
+      <div class="me-md-auto text-center text-md-start">
+        <div class="copyright">
+          &copy; Copyright <strong><span>C L I N I C A R E</span></strong>. All Rights Reserved
+        </div>
+
+      </div>
+      <div class="social-links text-center text-md-right pt-3 pt-md-0">
+        <a href="https://twitter.com/klinikdamai?s=20" class="twitter"><i class="bx bxl-twitter"></i></a>
+        <a href="https://www.facebook.com/klinikdamaikualaselangor24jam/" class="facebook"><i class="bx bxl-facebook"></i></a>
+        <a href="https://www.instagram.com/klinikdamaikualaselangor24jam/" class="instagram"><i class="bx bxl-instagram"></i></a>
+      </div>
+    </div>
+  </footer><!-- End Footer -->
+
+  <div id="preloader"></div>
+  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
+
+  <!-- Vendor JS Files -->
+  <script src="<?= $basePath ?>assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="<?= $basePath ?>assets/vendor/glightbox/js/glightbox.min.js"></script>
+  <script src="<?= $basePath ?>assets/vendor/php-email-form/validate.js"></script>
+  <script src="<?= $basePath ?>assets/vendor/purecounter/purecounter.js"></script>
+  <script src="<?= $basePath ?>assets/vendor/swiper/swiper-bundle.min.js"></script>
+
+  <!-- Template Main JS File -->
+  <script src="<?= $basePath ?>assets/js/main.js"></script>
+
+</body>
+</html>

--- a/CliniCare/app/Views/partials/header.php
+++ b/CliniCare/app/Views/partials/header.php
@@ -1,0 +1,82 @@
+<?php
+if (!isset($basePath)) {
+    $basePath = '';
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title>Welcome | CliniCare</title>
+  <meta content="" name="description">
+  <meta content="" name="keywords">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="<?= $basePath ?>bootstrap.css">
+
+  <!-- Favicons -->
+  <link href="<?= $basePath ?>assets/img/gambar/icon.jpeg" rel="icon">
+  <link href="<?= $basePath ?>assets/img/gambar/icon.jpeg" rel="apple-touch-icon">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="<?= $basePath ?>assets/vendor/animate.css/animate.min.css" rel="stylesheet">
+  <link href="<?= $basePath ?>assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="<?= $basePath ?>assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="<?= $basePath ?>assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+  <link href="<?= $basePath ?>assets/vendor/fontawesome-free/css/all.min.css" rel="stylesheet">
+  <link href="<?= $basePath ?>assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="<?= $basePath ?>assets/vendor/remixicon/remixicon.css" rel="stylesheet">
+  <link href="<?= $basePath ?>assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+  <script src="https://code.iconify.design/2/2.0.3/iconify.min.js"></script>
+
+  <!-- Template Main CSS File -->
+  <link href="<?= $basePath ?>assets/css/style.css" rel="stylesheet">
+
+</head>
+
+<body>
+
+  <!-- ======= Top Bar ======= -->
+  <div id="topbar" class="d-flex align-items-center fixed-top">
+    <div class="container d-flex justify-content-between">
+      <div class="contact-info d-flex align-items-center">
+        <i class="bi bi-envelope"></i> <a href="mailto:info@clinicare.com.my">info@clinicare.com.my</a>
+        <i class="bi bi-phone"></i> 03-3289 6079
+      </div>
+      <div class="d-none d-lg-flex social-links align-items-center">
+        <a href="https://twitter.com/klinikdamai?s=20" class="twitter"><i class="bi bi-twitter"></i></a>
+        <a href="https://www.facebook.com/klinikdamaikualaselangor24jam/" class="facebook"><i class="bi bi-facebook"></i></a>
+        <a href="https://www.instagram.com/klinikdamaikualaselangor24jam/" class="instagram"><i class="bi bi-instagram"></i></a>
+      </div>
+    </div>
+  </div>
+
+  <!-- ======= Header ======= -->
+  <header id="header" class="fixed-top">
+    <div class="container d-flex align-items-center">
+
+      <!-- Uncomment below if you prefer to use an image logo -->
+      <a href="<?= $basePath ?>index.php" class="logo me-auto"><img src="<?= $basePath ?>assets/img/gambar/logobanner.png" alt="" class="img-fluid"></a>
+
+      <nav id="navbar" class="navbar order-last order-lg-0">
+        <ul>
+          <li><a class="nav-link scrollto" href="<?= $basePath ?>index.php#hero">Home</a></li>
+          <li><a class="nav-link scrollto" href="<?= $basePath ?>index.php#about">About</a></li>
+          <li><a class="nav-link scrollto" href="<?= $basePath ?>index.php#services">Services</a></li>
+          <li><a class="nav-link scrollto" href="<?= $basePath ?>index.php#doctors">Doctors</a></li>
+          <li><a class="nav-link scrollto" href="<?= $basePath ?>index.php#faq">FAQ</a></li>
+          <li><a class="nav-link scrollto" href="<?= $basePath ?>index.php#contact">Contact Us</a></li>
+          <li><a class="nav-link scrollto" href="<?= $basePath ?>Guest/medicine/MedicineCatalogueGuest.php">Medicine</a></li>
+        </ul>
+        <i class="bi bi-list mobile-nav-toggle"></i>
+      </nav><!-- .navbar -->
+
+      <a href="<?= $basePath ?>Customer/Sign In Page/Sign In/signin.php"><button class="appointment-btn scrollto">Sign In / Sign Up</button></a>
+
+    </div>
+  </header><!-- End Header -->

--- a/CliniCare/index.php
+++ b/CliniCare/index.php
@@ -3,85 +3,9 @@ session_start();
 if (isset($_SESSION['email'])) {
   header("Location: Customer/CustomerHomePage/index.php");
 }
+$basePath = '';
+require __DIR__ . '/app/Views/partials/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-  <meta charset="utf-8">
-  <meta content="width=device-width, initial-scale=1.0" name="viewport">
-
-  <title>Welcome | CliniCare</title>
-  <meta content="" name="description">
-  <meta content="" name="keywords">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <link rel="stylesheet" href="bootstrap.css">
-
-  <!-- Favicons -->
-  <link href="assets/img/gambar/icon.jpeg" rel="icon">
-  <link href="assets/img/gambar/icon.jpeg" rel="apple-touch-icon">
-
-  <!-- Google Fonts -->
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
-
-  <!-- Vendor CSS Files -->
-  <link href="assets/vendor/animate.css/animate.min.css" rel="stylesheet">
-  <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-  <link href="assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
-  <link href="assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
-  <link href="assets/vendor/fontawesome-free/css/all.min.css" rel="stylesheet">
-  <link href="assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
-  <link href="assets/vendor/remixicon/remixicon.css" rel="stylesheet">
-  <link href="assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
-  <script src="https://code.iconify.design/2/2.0.3/iconify.min.js"></script>
-
-  <!-- Template Main CSS File -->
-  <link href="assets/css/style.css" rel="stylesheet">
-
-</head>
-
-<body>
-
-  <!-- ======= Top Bar ======= -->
-  <div id="topbar" class="d-flex align-items-center fixed-top">
-    <div class="container d-flex justify-content-between">
-      <div class="contact-info d-flex align-items-center">
-        <i class="bi bi-envelope"></i> <a href="mailto:info@clinicare.com.my">info@clinicare.com.my</a>
-        <i class="bi bi-phone"></i> 03-3289 6079
-      </div>
-      <div class="d-none d-lg-flex social-links align-items-center">
-        <a href="https://twitter.com/klinikdamai?s=20" class="twitter"><i class="bi bi-twitter"></i></a>
-        <a href="https://www.facebook.com/klinikdamaikualaselangor24jam/" class="facebook"><i class="bi bi-facebook"></i></a>
-        <a href="https://www.instagram.com/klinikdamaikualaselangor24jam/" class="instagram"><i class="bi bi-instagram"></i></a>
-      </div>
-    </div>
-  </div>
-
-  <!-- ======= Header ======= -->
-  <header id="header" class="fixed-top">
-    <div class="container d-flex align-items-center">
-
-      <!-- Uncomment below if you prefer to use an image logo -->
-      <a href="index.php" class="logo me-auto"><img src="assets/img/gambar/logobanner.png" alt="" class="img-fluid"></a>
-
-      <nav id="navbar" class="navbar order-last order-lg-0">
-        <ul>
-          <li><a class="nav-link scrollto active" href="#hero">Home</a></li>
-          <li><a class="nav-link scrollto" href="#about">About</a></li>
-          <li><a class="nav-link scrollto" href="#services">Services</a></li>
-          <li><a class="nav-link scrollto" href="#doctors">Doctors</a></li>
-          <li><a class="nav-link scrollto" href="#faq">FAQ</a></li>
-          <li><a class="nav-link scrollto" href="#contact">Contact Us</a></li>
-          <li><a href="Guest/medicine/MedicineCatalogueGuest.php">Medicine</a></li>
-        </ul>
-        <i class="bi bi-list mobile-nav-toggle"></i>
-      </nav><!-- .navbar -->
-
-      <a href="Customer/Sign In Page/Sign In/signin.php"><button class="appointment-btn scrollto">Sign In / Sign Up</button></a>
-
-    </div>
-  </header><!-- End Header -->
-
   <!-- ======= Hero Section ======= -->
   <section id="hero" class="d-flex align-items-center">
     <div class="container">
@@ -692,81 +616,7 @@ if (isset($_SESSION['email'])) {
     </section><!-- End Contact Section -->
 
   </main><!-- End #main -->
-
-  <!-- ======= Footer ======= -->
-  <footer id="footer">
-
-    <div class="footer-top">
-      <div class="container">
-        <div class="row">
-
-          <div class="col-lg-3 col-md-6 footer-contact">
-            <h3>C L I N I C A R E</h3>
-            <p>
-              No. 43 & 45, Jalan Melati 3/17, Bandar Melawati,<br>
-              45000 Kuala Selangor,<br>
-              Selangor<br><br>
-              <strong>Phone:</strong> 03-3289 6079<br>
-              <strong>Email:</strong> info@clinicare.com<br>
-            </p>
-          </div>
-
-          <div class="col-lg-2 col-md-6 footer-links">
-            <h4>Useful Links</h4>
-            <ul>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Home</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">About us</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Services</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Terms of service</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Privacy policy</a></li>
-            </ul>
-          </div>
-
-          <div class="col-lg-3 col-md-6 footer-links">
-            <h4>Our Services</h4>
-            <ul>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Pharmacy</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Primary Care</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Mom & Baby Care</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Medical Check-Up</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Swab Test Covid-19</a></li>
-              <li><i class="bx bx-chevron-right"></i> <a href="#">Smoking Cessation Campaign</a></li>
-            </ul>
-          </div>
-
-        </div>
-      </div>
-    </div>
-
-    <div class="container d-md-flex py-4">
-
-      <div class="me-md-auto text-center text-md-start">
-        <div class="copyright">
-          &copy; Copyright <strong><span>C L I N I C A R E</span></strong>. All Rights Reserved
-        </div>
-
-      </div>
-      <div class="social-links text-center text-md-right pt-3 pt-md-0">
-        <a href="https://twitter.com/klinikdamai?s=20" class="twitter"><i class="bx bxl-twitter"></i></a>
-        <a href="https://www.facebook.com/klinikdamaikualaselangor24jam/" class="facebook"><i class="bx bxl-facebook"></i></a>
-        <a href="https://www.instagram.com/klinikdamaikualaselangor24jam/" class="instagram"><i class="bx bxl-instagram"></i></a>
-      </div>
-    </div>
-  </footer><!-- End Footer -->
-
-  <div id="preloader"></div>
-  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
-
-  <!-- Vendor JS Files -->
-  <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="assets/vendor/glightbox/js/glightbox.min.js"></script>
-  <script src="assets/vendor/php-email-form/validate.js"></script>
-  <script src="assets/vendor/purecounter/purecounter.js"></script>
-  <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
-
-  <!-- Template Main JS File -->
-  <script src="assets/js/main.js"></script>
-
-</body>
-
-</html>
+<?php
+$basePath = '';
+require __DIR__ . '/app/Views/partials/footer.php';
+?>


### PR DESCRIPTION
## Summary
- centralize shared layout into `app/Views/partials/header.php` and `footer.php`
- include header and footer partials in `index.php` and guest medicine catalogue
- handle asset paths via configurable `$basePath` variable

## Testing
- `php -l app/Views/partials/header.php`
- `php -l app/Views/partials/footer.php`
- `php -l index.php`
- `php -l Guest/medicine/MedicineCatalogueGuest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aff339d4e483208f304af3c6896a49