### PR TITLE
Add Monolog logging and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/logs/

--- a/CliniCare/AdminPage/db_conn.php
+++ b/CliniCare/AdminPage/db_conn.php
@@ -1,8 +1,13 @@
 <?php
 
-$con = mysqli_connect("localhost", "clinicarecustomer", "customer", "clinicare");
-//$con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
+require_once __DIR__ . '/../logger.php';
 
-if (!$con) {
-	echo "Connection failed!";
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+try {
+    $con = mysqli_connect("localhost", "clinicarecustomer", "customer", "clinicare");
+    // $con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
+} catch (mysqli_sql_exception $e) {
+    getLogger()->error('Database connection failed: ' . $e->getMessage());
+    die('Database connection error. Please try again later.');
 }

--- a/CliniCare/Customer/CustomerHomePage/giveFeedback.php
+++ b/CliniCare/Customer/CustomerHomePage/giveFeedback.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../../logger.php';
+
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\PHPMailer\Exception;
@@ -302,8 +304,9 @@ if (isset($_POST['btn-send'])) {
       $mail->send();
       //if mail is sent successfully
       header('location:index.php?success');
-    } catch (Exception $e) {
-      echo "Message could not be sent. Mailer Error: {$mail->ErrorInfo}";
+    } catch (\Exception $e) {
+      getLogger()->error('Feedback email failed: ' . $e->getMessage());
+      echo 'Unable to send your message at this time. Please try again later.';
     }
   }
 }

--- a/CliniCare/Customer/Index Pages/medicine/db_conn.php
+++ b/CliniCare/Customer/Index Pages/medicine/db_conn.php
@@ -1,7 +1,12 @@
 <?php
 
-$con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
+require_once __DIR__ . '/../../../logger.php';
 
-if (!$con) {
-	echo "Connection failed!";
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+try {
+    $con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
+} catch (mysqli_sql_exception $e) {
+    getLogger()->error('Database connection failed: ' . $e->getMessage());
+    die('Database connection error. Please try again later.');
 }

--- a/CliniCare/Customer/db_conn.php
+++ b/CliniCare/Customer/db_conn.php
@@ -1,8 +1,13 @@
 <?php
 
-$con = mysqli_connect("localhost", "clinicarecustomer", "customer", "clinicare");
-//$con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
+require_once __DIR__ . '/../logger.php';
 
-if (!$con) {
-	echo "Connection failed!";
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+try {
+    $con = mysqli_connect("localhost", "clinicarecustomer", "customer", "clinicare");
+    // $con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
+} catch (mysqli_sql_exception $e) {
+    getLogger()->error('Database connection failed: ' . $e->getMessage());
+    die('Database connection error. Please try again later.');
 }

--- a/CliniCare/giveFeedback.php
+++ b/CliniCare/giveFeedback.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/logger.php';
+
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\PHPMailer\Exception;
@@ -302,8 +304,9 @@ if (isset($_POST['btn-send'])) {
       $mail->send();
       //if mail is sent successfully
       header('location:index.php?success');
-    } catch (Exception $e) {
-      echo "Message could not be sent. Mailer Error: {$mail->ErrorInfo}";
+    } catch (\Exception $e) {
+      getLogger()->error('Feedback email failed: ' . $e->getMessage());
+      echo 'Unable to send your message at this time. Please try again later.';
     }
   }
 }

--- a/CliniCare/logger.php
+++ b/CliniCare/logger.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+function getLogger(): Logger {
+    static $logger = null;
+    if ($logger === null) {
+        $logger = new Logger('app');
+        $logDir = __DIR__ . '/../logs';
+        if (!is_dir($logDir)) {
+            mkdir($logDir, 0777, true);
+        }
+        $logger->pushHandler(new StreamHandler($logDir . '/app.log', Logger::DEBUG));
+    }
+    return $logger;
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "^3.9"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,172 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "588ba73f55c66c3f09586a66893d3afc",
+    "packages": [
+        {
+            "name": "monolog/monolog",
+            "version": "3.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-24T10:02:05+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
## Summary
- Integrate Monolog via Composer and centralize logger setup
- Wrap database and mail operations in try/catch with server-side logging
- Show user-friendly errors for database and email failures

## Testing
- `php -l CliniCare/logger.php`
- `php -l CliniCare/Customer/db_conn.php`
- `php -l CliniCare/AdminPage/db_conn.php`
- `php -l "CliniCare/Customer/Index Pages/medicine/db_conn.php"`
- `php -l CliniCare/Customer/CustomerEntry.php`
- `php -l CliniCare/giveFeedback.php`
- `php -l CliniCare/Customer/CustomerHomePage/giveFeedback.php`


------
https://chatgpt.com/codex/tasks/task_e_68aff3377e7c8320b7f5463ce8036a72