### PR TITLE
fix: correct POST keys and add PHP linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: php-lint
+        name: PHP syntax check
+        entry: php -l
+        language: system
+        types: [php]
+

--- a/CliniCare/AdminPage/AdminEntry.php
+++ b/CliniCare/AdminPage/AdminEntry.php
@@ -6,9 +6,9 @@ if (isset($_POST['deleteCustomer'])) {
 } else if (isset($_POST['editCustomer'])) {
     header("Location: ../AdminPage/dist/editCustomer.php");
 } else if (isset($_POST['closeAppointment'])) {
-    closeAppointment($__POST['closeAppointment']);
+    closeAppointment($_POST['closeAppointment']);
 } else if (isset($_POST['openAppointment'])) {
-    openAppointment($__POST['openAppointment']);
+    openAppointment($_POST['openAppointment']);
 } else if (isset($_POST['updateCustomer'])) {
     updateCustomer($_POST['updateCustomer']);
 } else if (isset($_POST['updateProfileAdmin'])) {


### PR DESCRIPTION
## Summary
- fix misspelled `$_POST` references for opening and closing appointments
- add pre-commit PHP linter to catch syntax errors

## Testing
- `php -l CliniCare/AdminPage/AdminEntry.php`
- `pre-commit run --files CliniCare/AdminPage/AdminEntry.php`
- `pre-commit run --files .pre-commit-config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68aff331e26483208148ee0eb932dc70