### PR TITLE
Add role-based auth middleware for admin pages

### DIFF
--- a/CliniCare/AdminPage/AdminEntry.php
+++ b/CliniCare/AdminPage/AdminEntry.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require_once __DIR__ . '/../app/Middleware/Auth.php';
+Auth::requireRole('admin', '../index.php');
 
 if (isset($_POST['deleteCustomer'])) {
     deleteCustomer($_POST['deleteCustomer']);

--- a/CliniCare/AdminPage/dist/EditFunction.php
+++ b/CliniCare/AdminPage/dist/EditFunction.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 
 function getCustomerInfo($email)
 {

--- a/CliniCare/AdminPage/dist/addSlot.php
+++ b/CliniCare/AdminPage/dist/addSlot.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 ?>
 
 <!DOCTYPE html>

--- a/CliniCare/AdminPage/dist/appointmentList.php
+++ b/CliniCare/AdminPage/dist/appointmentList.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 ?>
 
 <!DOCTYPE html>

--- a/CliniCare/AdminPage/dist/appointmentSlot.php
+++ b/CliniCare/AdminPage/dist/appointmentSlot.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 ?>
 
 <!DOCTYPE html>

--- a/CliniCare/AdminPage/dist/change-p.php
+++ b/CliniCare/AdminPage/dist/change-p.php
@@ -1,9 +1,11 @@
 <?php
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 
 if (isset($_SESSION['email']) && isset($_SESSION['email'])) {
 
-	include "../db_conn.php";
+        include "../db_conn.php";
 
 	if (
 		isset($_POST['op']) && isset($_POST['np'])

--- a/CliniCare/AdminPage/dist/customerList.php
+++ b/CliniCare/AdminPage/dist/customerList.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 ?>
 
 <!DOCTYPE html>
@@ -128,7 +126,7 @@ if (!isset($_SESSION['email'])) {
                       <?php
                       include "../db_conn.php";
                       $sql = "SELECT customer.name, customer.email, customer.phoneNumber, customer.ICnumber, customer.birthDate FROM customer 
-                      INNER JOIN user ON customer.email = user.email WHERE user.usertype = 'customer' order by name";
+                      INNER JOIN user ON customer.email = user.email WHERE user.role = 'customer' order by name";
                       $result = mysqli_query($con, $sql);
                       $x = 1;
                       while ($row = mysqli_fetch_array($result)) {

--- a/CliniCare/AdminPage/dist/editCustomer.php
+++ b/CliniCare/AdminPage/dist/editCustomer.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 ?>
 
 <!DOCTYPE html>

--- a/CliniCare/AdminPage/dist/index.php
+++ b/CliniCare/AdminPage/dist/index.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 ?>
 
 <!DOCTYPE html>

--- a/CliniCare/AdminPage/dist/paymentHistory.php
+++ b/CliniCare/AdminPage/dist/paymentHistory.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 ?>
 
 <!DOCTYPE html>

--- a/CliniCare/AdminPage/dist/profile.php
+++ b/CliniCare/AdminPage/dist/profile.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 
 if (isset($_POST['submit'])) {
   move_uploaded_file($_FILES['file']['tmp_name'], "pictures/" . $_FILES['file']['name']);

--- a/CliniCare/AdminPage/dist/purchaseHistory.php
+++ b/CliniCare/AdminPage/dist/purchaseHistory.php
@@ -1,13 +1,11 @@
 <?php
 include "../db_conn.php";
 session_start();
+require_once __DIR__ . '/../../app/Middleware/Auth.php';
+Auth::requireRole('admin');
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
-if (!isset($_SESSION['email'])) {
-  header("Location: ../../index.php");
-  exit;
-}
 ?>
 
 <!DOCTYPE html>

--- a/CliniCare/Customer/CustomerEntry.php
+++ b/CliniCare/Customer/CustomerEntry.php
@@ -359,7 +359,7 @@ function signup()
       $mail->send();
 
 
-      $sql2 = "INSERT INTO user (email, usertype)
+      $sql2 = "INSERT INTO user (email, role)
                             VALUES('$email', 'customer')";
       if ($con->query($sql2) === TRUE) {
         //kalau dah successful buat sign up, keluar page ni
@@ -400,9 +400,10 @@ function signin()
       if ($result3->num_rows != 0) {
 
         $row = $result3->fetch_assoc();
-        $usertype = $row['usertype'];
+        $role = $row['role'];
+        $_SESSION['role'] = $role;
 
-        if ($usertype == "customer") {
+        if ($role == "customer") {
           header("Location: ../Customer/CustomerHomePage/index.php");
         } else {
           header("Location: ../AdminPage/dist/index.php");

--- a/CliniCare/app/Middleware/Auth.php
+++ b/CliniCare/app/Middleware/Auth.php
@@ -1,0 +1,14 @@
+<?php
+class Auth
+{
+    public static function requireRole(string $role, string $redirect = '../../index.php')
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (!isset($_SESSION['email']) || !isset($_SESSION['role']) || $_SESSION['role'] !== $role) {
+            header("Location: $redirect");
+            exit;
+        }
+    }
+}

--- a/CliniCare/database/add_role_column.sql
+++ b/CliniCare/database/add_role_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user
+    CHANGE COLUMN usertype role ENUM('admin','customer') NOT NULL DEFAULT 'customer';


### PR DESCRIPTION
## Summary
- add SQL migration to rename usertype column to role with admin/customer options
- implement reusable Auth middleware to enforce session role
- guard admin entry points and pages using middleware and store user role during login

## Testing
- `php -l CliniCare/app/Middleware/Auth.php`
- `for file in CliniCare/AdminPage/AdminEntry.php CliniCare/AdminPage/dist/EditFunction.php CliniCare/AdminPage/dist/addSlot.php CliniCare/AdminPage/dist/appointmentList.php CliniCare/AdminPage/dist/appointmentSlot.php CliniCare/AdminPage/dist/change-p.php CliniCare/AdminPage/dist/customerList.php CliniCare/AdminPage/dist/editCustomer.php CliniCare/AdminPage/dist/index.php CliniCare/AdminPage/dist/paymentHistory.php CliniCare/AdminPage/dist/profile.php CliniCare/AdminPage/dist/purchaseHistory.php CliniCare/Customer/CustomerEntry.php; do php -l $file; done`

------
https://chatgpt.com/codex/tasks/task_e_68aff330c628832084a65353f5a653cc