### PR TITLE
Use secure password hashing

### DIFF
--- a/CliniCare/Customer/CustomerEntry.php
+++ b/CliniCare/Customer/CustomerEntry.php
@@ -47,7 +47,7 @@ function signup()
     $icNumber = $_POST['icNumber'];
     $birthDate = $_POST['birthDate'];
 
-    $password = md5($password);
+    $password = password_hash($password, PASSWORD_DEFAULT);
     //Generate Vkey
     $vkey = md5(time() . $name);
 
@@ -380,14 +380,31 @@ function signin()
 
   $email = $_POST['email'];
   $password = $_POST['password'];
-  $password = md5($password);
 
-  $query = "SELECT * FROM customer  WHERE email = '$email' AND password = '$password' LIMIT 1 ";
+  $query = "SELECT * FROM customer  WHERE email = '$email' LIMIT 1 ";
   $result = mysqli_query($con, $query);
 
   if ($result->num_rows != 0) {
     //Process login
     $row = $result->fetch_assoc();
+    $storedPwd = $row['password'];
+
+    if (password_verify($password, $storedPwd)) {
+      // password verified
+    } else if (password_verify(md5($password), $storedPwd)) {
+      // migrated hash based on md5, upgrade to direct hash
+      $newHash = password_hash($password, PASSWORD_DEFAULT);
+      mysqli_query($con, "UPDATE customer SET password = '$newHash' WHERE email = '$email'");
+    } else if ($storedPwd === md5($password)) {
+      // legacy md5 hash, upgrade to modern hash
+      $newHash = password_hash($password, PASSWORD_DEFAULT);
+      mysqli_query($con, "UPDATE customer SET password = '$newHash' WHERE email = '$email'");
+    } else {
+      //Invalid login
+      header("Location: ../Alerts/unsuccessWRONG.php");
+      return;
+    }
+
     $verified = $row['verified'];
     $email = $row['email'];
     $_SESSION['email'] = $email;
@@ -778,7 +795,7 @@ function resetPassword()
     exit();
   } else if ($pwd == $pwdR) {
 
-    $pwd = md5($pwd);
+    $pwd = password_hash($pwd, PASSWORD_DEFAULT);
     include "db_conn.php";
 
     if (!$con) {
@@ -819,8 +836,6 @@ function updateProfile()
     $icNumber = $_POST['icNumber'];
     $birthDate = $_POST['birthDate'];
     $address = $_POST['address'];
-
-    $password = md5($password);
 
     $sql = "UPDATE customer SET name = '$name', address = '$address', phoneNumber = '$phoneNumber',
              icNumber = '$icNumber', birthDate = '$birthDate' WHERE email = '$email'";

--- a/CliniCare/Customer/migrate_passwords.php
+++ b/CliniCare/Customer/migrate_passwords.php
@@ -1,0 +1,23 @@
+<?php
+// Script to migrate existing MD5 hashed passwords to password_hash.
+// This will hash the current MD5 values so that sign-in can verify using password_verify.
+
+include 'db_conn.php';
+
+if (!$con) {
+    die('Database connection failed');
+}
+
+$query = mysqli_query($con, "SELECT email, password FROM customer");
+while ($row = mysqli_fetch_assoc($query)) {
+    $email = $row['email'];
+    $current = $row['password'];
+
+    // Detect legacy MD5 hashes (32 hex characters)
+    if (strlen($current) === 32 && ctype_xdigit($current)) {
+        $newHash = password_hash($current, PASSWORD_DEFAULT);
+        mysqli_query($con, "UPDATE customer SET password='$newHash' WHERE email='$email'");
+    }
+}
+
+echo "Password migration complete\n";


### PR DESCRIPTION
## Summary
- replace legacy md5 password storage with `password_hash`
- validate logins using `password_verify` with fallback for legacy hashes
- add `migrate_passwords.php` script to rehash existing md5 passwords

## Testing
- `php -l CliniCare/Customer/CustomerEntry.php`
- `php -l CliniCare/Customer/migrate_passwords.php`


------
https://chatgpt.com/codex/tasks/task_e_68aff33095748320892d601b0f28dbfa