### PR TITLE
Add input validation helper and apply to entry points

### DIFF
--- a/CliniCare/AdminPage/AdminEntry.php
+++ b/CliniCare/AdminPage/AdminEntry.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once __DIR__ . '/../app/Helpers/Input.php';
 
 if (isset($_POST['deleteCustomer'])) {
     deleteCustomer($_POST['deleteCustomer']);
@@ -34,12 +35,26 @@ function updateProfileAdmin()
         echo "Error";
     } else {
 
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'name' => 'string',
+            'phoneNumber' => 'string',
+            'icNumber' => 'string',
+            'birthDate' => 'date',
+            'address' => 'string'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
         $email = $_SESSION['email'];
-        $name = $_POST['name'];
-        $phoneNumber = $_POST['phoneNumber'];
-        $icNumber = $_POST['icNumber'];
-        $birthDate = $_POST['birthDate'];
-        $address = $_POST['address'];
+        $name = $data['name'];
+        $phoneNumber = $data['phoneNumber'];
+        $icNumber = $data['icNumber'];
+        $birthDate = $data['birthDate'];
+        $address = $data['address'];
 
         $sql = "UPDATE customer SET name = '$name', address = '$address', phoneNumber = '$phoneNumber',
              icNumber = '$icNumber', birthDate = '$birthDate' WHERE email = '$email'";
@@ -72,7 +87,17 @@ function deleteCustomer()
     if (!$con) {
         echo "Error";
     } else {
-        $email = $_POST['emailToDelete'];
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'emailToDelete' => 'email'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
+        $email = $data['emailToDelete'];
         $sql = "DELETE FROM customer WHERE email = '$email' ";
         if ($con->query($sql) === TRUE) {
             $sql2 = "DELETE FROM user WHERE email = '$email'";
@@ -94,11 +119,25 @@ function updateCustomer()
     if (!$con) {
         echo "Error";
     } else {
-        $email = $_POST['email'];
-        $name = $_POST['name'];
-        $phoneNumber = $_POST['phoneNumber'];
-        $ICnumber = $_POST['ICnumber'];
-        $birthDate = $_POST['birthDate'];
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'email' => 'email',
+            'name' => 'string',
+            'phoneNumber' => 'string',
+            'ICnumber' => 'string',
+            'birthDate' => 'date'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
+        $email = $data['email'];
+        $name = $data['name'];
+        $phoneNumber = $data['phoneNumber'];
+        $ICnumber = $data['ICnumber'];
+        $birthDate = $data['birthDate'];
 
         $sql = "UPDATE customer SET name = '$name', phoneNumber = '$phoneNumber',
              ICnumber = '$ICnumber', birthDate = '$birthDate 'WHERE email = '$email'";
@@ -119,7 +158,17 @@ function closeAppointment()
     if (!$con) {
         echo "Error";
     } else {
-        $appSId = $_POST['appToClose'];
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'appToClose' => 'int'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
+        $appSId = $data['appToClose'];
         $sql = "UPDATE appointmentslot SET status = 1 WHERE appSId = '$appSId' ";
 
         if ($con->query($sql) === TRUE) {
@@ -137,7 +186,17 @@ function openAppointment()
     if (!$con) {
         echo "Error";
     } else {
-        $appSId = $_POST['appToOpen'];
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'appToOpen' => 'int'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
+        $appSId = $data['appToOpen'];
 
         $sql = "UPDATE appointmentslot SET status = 0 WHERE appSId = '$appSId' ";
 
@@ -156,7 +215,17 @@ function deleteSlot()
     if (!$con) {
         echo "Error";
     } else {
-        $appSId = $_POST['SlotToDelete'];
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'SlotToDelete' => 'int'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
+        $appSId = $data['SlotToDelete'];
         $sql = "DELETE FROM appointmentslot WHERE appSId='" . $appSId . "'";
 
         if ($con->query($sql) === TRUE) {
@@ -177,7 +246,18 @@ function addSlot()
         $time1 = "9AM - 1PM";
         $time2 = "2PM - 6PM";
         $time3 = "7PM - 11PM";
-        $date = $_POST['date'];
+
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'date' => 'date'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
+        $date = $data['date'];
         $dateToday = date("Y-m-d");
 
         $query = mysqli_query($con, "SELECT * FROM appointmentslot WHERE date = '$date'");
@@ -214,8 +294,18 @@ function doneApp()
     if (!$con) {
         echo "Error";
     } else {
-        $appID = $_POST['appID'];
-        //update table appointment status = 0 
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'appID' => 'int'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
+        $appID = $data['appID'];
+        //update table appointment status = 0
         $sql = "UPDATE appointment SET status = 0 WHERE appId = '$appID'";
         if ($con->query($sql) === TRUE) {
             header("Location: ../AdminPage/dist/appointmentList.php");
@@ -232,8 +322,18 @@ function cancelApp()
     if (!$con) {
         echo "Error";
     } else {
-        $appID = $_POST['appID'];
-        //update table appointment status = 2 
+        list($data, $errors) = Input::sanitizeArray($_POST, [
+            'appID' => 'int'
+        ]);
+
+        if ($errors) {
+            header('Content-Type: application/json');
+            echo json_encode(['success' => false, 'errors' => $errors]);
+            return;
+        }
+
+        $appID = $data['appID'];
+        //update table appointment status = 2
         $sql = "UPDATE appointment SET status = 2 WHERE appId = '$appID'";
         if ($con->query($sql) === TRUE) {
             header("Location: ../AdminPage/dist/appointmentList.php");

--- a/CliniCare/Customer/CustomerEntry.php
+++ b/CliniCare/Customer/CustomerEntry.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once __DIR__ . '/../app/Helpers/Input.php';
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
@@ -40,12 +41,27 @@ function signup()
     echo "error";
   } else {
     //2. Construct SQL statement
-    $name = $_POST['name'];
-    $email = $_POST['email'];
-    $password = $_POST['password'];
-    $phoneNumber = $_POST['phoneNumber'];
-    $icNumber = $_POST['icNumber'];
-    $birthDate = $_POST['birthDate'];
+    list($data, $errors) = Input::sanitizeArray($_POST, [
+      'name' => 'string',
+      'email' => 'email',
+      'password' => 'string',
+      'phoneNumber' => 'string',
+      'icNumber' => 'string',
+      'birthDate' => 'date'
+    ]);
+
+    if ($errors) {
+      header('Content-Type: application/json');
+      echo json_encode(['success' => false, 'errors' => $errors]);
+      return;
+    }
+
+    $name = $data['name'];
+    $email = $data['email'];
+    $password = $data['password'];
+    $phoneNumber = $data['phoneNumber'];
+    $icNumber = $data['icNumber'];
+    $birthDate = $data['birthDate'];
 
     $password = md5($password);
     //Generate Vkey
@@ -378,9 +394,19 @@ function signin()
 {
   include "db_conn.php";
 
-  $email = $_POST['email'];
-  $password = $_POST['password'];
-  $password = md5($password);
+  list($data, $errors) = Input::sanitizeArray($_POST, [
+    'email' => 'email',
+    'password' => 'string'
+  ]);
+
+  if ($errors) {
+    header('Content-Type: application/json');
+    echo json_encode(['success' => false, 'errors' => $errors]);
+    return;
+  }
+
+  $email = $data['email'];
+  $password = md5($data['password']);
 
   $query = "SELECT * FROM customer  WHERE email = '$email' AND password = '$password' LIMIT 1 ";
   $result = mysqli_query($con, $query);
@@ -433,7 +459,17 @@ function getVkey()
     echo "No connection";
   } else {
     //Construct SQL statement
-    $email = $_POST['email'];
+    list($data, $errors) = Input::sanitizeArray($_POST, [
+      'email' => 'email'
+    ]);
+
+    if ($errors) {
+      header('Content-Type: application/json');
+      echo json_encode(['success' => false, 'errors' => $errors]);
+      return;
+    }
+
+    $email = $data['email'];
 
     $sql = "SELECT vkey FROM customer WHERE email='$email'";
     $qry = mysqli_query($con, $sql);
@@ -770,8 +806,19 @@ function resetPassword()
 {
   $vkey = $_SESSION['resetVkey'];
 
-  $pwd = $_POST['pwd'];
-  $pwdR = $_POST['pwd-repeat'];
+  list($data, $errors) = Input::sanitizeArray($_POST, [
+    'pwd' => 'string',
+    'pwd-repeat' => 'string'
+  ]);
+
+  if ($errors) {
+    header('Content-Type: application/json');
+    echo json_encode(['success' => false, 'errors' => $errors]);
+    return;
+  }
+
+  $pwd = $data['pwd'];
+  $pwdR = $data['pwd-repeat'];
 
   if (strlen($pwd) < 2 || strlen($pwdR) < 2) {
     header("Location: ../index.php");
@@ -814,13 +861,25 @@ function updateProfile()
 
     $email = $_SESSION['email'];
 
-    $name = $_POST['name'];
-    $phoneNumber = $_POST['phoneNumber'];
-    $icNumber = $_POST['icNumber'];
-    $birthDate = $_POST['birthDate'];
-    $address = $_POST['address'];
+    list($data, $errors) = Input::sanitizeArray($_POST, [
+      'name' => 'string',
+      'phoneNumber' => 'string',
+      'icNumber' => 'string',
+      'birthDate' => 'date',
+      'address' => 'string'
+    ]);
 
-    $password = md5($password);
+    if ($errors) {
+      header('Content-Type: application/json');
+      echo json_encode(['success' => false, 'errors' => $errors]);
+      return;
+    }
+
+    $name = $data['name'];
+    $phoneNumber = $data['phoneNumber'];
+    $icNumber = $data['icNumber'];
+    $birthDate = $data['birthDate'];
+    $address = $data['address'];
 
     $sql = "UPDATE customer SET name = '$name', address = '$address', phoneNumber = '$phoneNumber',
              icNumber = '$icNumber', birthDate = '$birthDate' WHERE email = '$email'";
@@ -842,10 +901,23 @@ function bookApp()
   } else {
     $email = $_SESSION['email'];
 
-    $name = $_POST['name'];
-    $phoneNumber = $_POST['phoneNumber'];
-    $date = $_POST['date'];
-    $time = $_POST['time'];
+    list($data, $errors) = Input::sanitizeArray($_POST, [
+      'name' => 'string',
+      'phoneNumber' => 'string',
+      'date' => 'date',
+      'time' => 'string'
+    ]);
+
+    if ($errors) {
+      header('Content-Type: application/json');
+      echo json_encode(['success' => false, 'errors' => $errors]);
+      return;
+    }
+
+    $name = $data['name'];
+    $phoneNumber = $data['phoneNumber'];
+    $date = $data['date'];
+    $time = $data['time'];
     $dateToday = date("Y-m-d");
 
     //check if date is past today

--- a/CliniCare/app/Helpers/Input.php
+++ b/CliniCare/app/Helpers/Input.php
@@ -1,0 +1,64 @@
+<?php
+
+class Input
+{
+    public static function trim($value)
+    {
+        return is_string($value) ? trim($value) : $value;
+    }
+
+    public static function sanitize($value)
+    {
+        return filter_var(self::trim($value), FILTER_SANITIZE_STRING);
+    }
+
+    public static function validate($value, $type = 'string')
+    {
+        $value = self::trim($value);
+        if ($value === null || $value === '') {
+            return [false, 'Required'];
+        }
+
+        switch ($type) {
+            case 'email':
+                if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                    return [false, 'Invalid email'];
+                }
+                break;
+            case 'int':
+                if (filter_var($value, FILTER_VALIDATE_INT) === false) {
+                    return [false, 'Invalid integer'];
+                }
+                break;
+            case 'date':
+                $d = \DateTime::createFromFormat('Y-m-d', $value);
+                if (!$d || $d->format('Y-m-d') !== $value) {
+                    return [false, 'Invalid date'];
+                }
+                break;
+            case 'string':
+            default:
+                // no extra validation
+        }
+
+        return [true, self::sanitize($value)];
+    }
+
+    public static function sanitizeArray($input, $rules)
+    {
+        $sanitized = [];
+        $errors = [];
+        foreach ($rules as $field => $type) {
+            $value = $input[$field] ?? null;
+            list($valid, $result) = self::validate($value, $type);
+            if (!$valid) {
+                $errors[$field] = $result;
+            } else {
+                $sanitized[$field] = $result;
+            }
+        }
+        return [$sanitized, $errors];
+    }
+}
+
+?>


### PR DESCRIPTION
## Summary
- add reusable Input helper for trimming, sanitizing, and validating fields
- validate and sanitize all AdminEntry endpoints
- enforce validation for CustomerEntry actions with structured JSON errors

## Testing
- `php -l CliniCare/app/Helpers/Input.php`
- `php -l CliniCare/AdminPage/AdminEntry.php`
- `php -l CliniCare/Customer/CustomerEntry.php`


------
https://chatgpt.com/codex/tasks/task_e_68aff32f728483208eb92275aee7d317