### PR TITLE
Use prepared statements for database operations

### DIFF
--- a/CliniCare/db_functions.php
+++ b/CliniCare/db_functions.php
@@ -1,0 +1,19 @@
+<?php
+function run_prepared_query($con, $sql, $params = [], $types = '') {
+    $stmt = mysqli_prepare($con, $sql);
+    if (!$stmt) {
+        return false;
+    }
+    if ($params) {
+        if ($types === '') {
+            $types = str_repeat('s', count($params));
+        }
+        mysqli_stmt_bind_param($stmt, $types, ...$params);
+    }
+    if (!mysqli_stmt_execute($stmt)) {
+        mysqli_stmt_close($stmt);
+        return false;
+    }
+    return $stmt;
+}
+?>


### PR DESCRIPTION
## Summary
- add reusable `run_prepared_query` helper for safer parameterized SQL
- refactor admin and customer entries to use prepared statements with bound parameters
- centralize repeated query logic into the new helper

## Testing
- `php -l CliniCare/AdminPage/AdminEntry.php`
- `php -l CliniCare/Customer/CustomerEntry.php`
- `php -l CliniCare/db_functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68aff32e5f8083209af1c851479b6e4a