### PR TITLE
refactor: centralize db config via env vars

### DIFF
--- a/CliniCare/AdminPage/db_conn.php
+++ b/CliniCare/AdminPage/db_conn.php
@@ -1,8 +1,2 @@
 <?php
-
-$con = mysqli_connect("localhost", "clinicarecustomer", "customer", "clinicare");
-//$con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
-
-if (!$con) {
-	echo "Connection failed!";
-}
+require 'config/database.php';

--- a/CliniCare/Customer/Index Pages/medicine/db_conn.php
+++ b/CliniCare/Customer/Index Pages/medicine/db_conn.php
@@ -1,7 +1,2 @@
 <?php
-
-$con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
-
-if (!$con) {
-	echo "Connection failed!";
-}
+require 'config/database.php';

--- a/CliniCare/Customer/db_conn.php
+++ b/CliniCare/Customer/db_conn.php
@@ -1,8 +1,2 @@
 <?php
-
-$con = mysqli_connect("localhost", "clinicarecustomer", "customer", "clinicare");
-//$con = mysqli_connect("localhost", "clinicar_user", "clinicare123", "clinicar_clinicare");
-
-if (!$con) {
-	echo "Connection failed!";
-}
+require 'config/database.php';

--- a/CliniCare/config/database.php
+++ b/CliniCare/config/database.php
@@ -1,0 +1,11 @@
+<?php
+$host = getenv('DB_HOST');
+$user = getenv('DB_USER');
+$pass = getenv('DB_PASS');
+$name = getenv('DB_NAME');
+
+$con = mysqli_connect($host, $user, $pass, $name);
+
+if (!$con) {
+    die('Connection failed: ' . mysqli_connect_error());
+}

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,15 @@ Installation Manual for UniServer
 8. Display database page by clicking button phpMyAdmin or type http://localhost/us_opt1 into your browser.
 ```
 
+## Environment Variables
+
+Set the following environment variables to configure the database connection:
+
+- `DB_HOST` – database host
+- `DB_USER` – database username
+- `DB_PASS` – database password
+- `DB_NAME` – database name
+
 ## Project Usernames/Passwords
 
 ```bash


### PR DESCRIPTION
## Summary
- read DB connection details from environment variables
- use shared database config across `db_conn.php` scripts
- document required DB environment variables

## Testing
- `php -l CliniCare/config/database.php`
- `php -l CliniCare/Customer/db_conn.php`
- `php -l CliniCare/AdminPage/db_conn.php`
- `php -l 'CliniCare/Customer/Index Pages/medicine/db_conn.php'`


------
https://chatgpt.com/codex/tasks/task_e_68aff32de9d48320b16385089b0d8d7c