### PR TITLE
Add CSRF token validation

### DIFF
--- a/CliniCare/AdminPage/AdminEntry.php
+++ b/CliniCare/AdminPage/AdminEntry.php
@@ -1,5 +1,15 @@
 <?php
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    if (!isset($_POST["csrf_token"]) || !hash_equals($_SESSION["csrf_token"], $_POST["csrf_token"])) {
+        die("Invalid CSRF token");
+    }
+    unset($_SESSION["csrf_token"]);
+}
+
 
 if (isset($_POST['deleteCustomer'])) {
     deleteCustomer($_POST['deleteCustomer']);

--- a/CliniCare/AdminPage/dist/addSlot.php
+++ b/CliniCare/AdminPage/dist/addSlot.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -39,6 +43,7 @@ if (!isset($_SESSION['email'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -54,6 +59,7 @@ if (!isset($_SESSION['email'])) {
               </a>
               <a href="#" class="dropdown-item has-icon">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>
@@ -108,6 +114,7 @@ if (!isset($_SESSION['email'])) {
               </div>
               <div class="card-body">
                 <form action="../AdminEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <div class="form-group">
                     <h6>Date</h6>
                     <input name="date" id="date" type="date" class="form-control">

--- a/CliniCare/AdminPage/dist/appointmentList.php
+++ b/CliniCare/AdminPage/dist/appointmentList.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -42,6 +46,7 @@ if (!isset($_SESSION['email'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -57,6 +62,7 @@ if (!isset($_SESSION['email'])) {
               </a>
               <a href="#" class="dropdown-item has-icon">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>
@@ -151,6 +157,7 @@ if (!isset($_SESSION['email'])) {
                         }else{
                           if ($row['status'] == 1) {
                             echo '<td><form action="../AdminEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                           <input type="hidden" name="appID" id="appID" value="' . $appID . '" > 
                           <button type="submit" name="doneApp" id="doneApp" title="Update Completed" class="btn btn-icon btn-primary">
                           <h7>&#10003;<h7></button> 

--- a/CliniCare/AdminPage/dist/appointmentSlot.php
+++ b/CliniCare/AdminPage/dist/appointmentSlot.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -42,6 +46,7 @@ if (!isset($_SESSION['email'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -57,6 +62,7 @@ if (!isset($_SESSION['email'])) {
               </a>
               <a href="#" class="dropdown-item has-icon">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>
@@ -149,7 +155,8 @@ if (!isset($_SESSION['email'])) {
                         $appSId = $row['appSId'];
 
 
-                        echo '<td><form action="../AdminEntry.php" method="POST">';
+                        echo '<td><form action="../AdminEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">';
 
                         echo '<input type="hidden" name="appToClose" 
 												value="' . $appSId . '" >';

--- a/CliniCare/AdminPage/dist/customerList.php
+++ b/CliniCare/AdminPage/dist/customerList.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -42,6 +46,7 @@ if (!isset($_SESSION['email'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -58,6 +63,7 @@ if (!isset($_SESSION['email'])) {
               <div class="dropdown-divider"></div>
               <a href="#" class="dropdown-item has-icon text-danger">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>
@@ -142,7 +148,8 @@ if (!isset($_SESSION['email'])) {
 
                         $customerS = $row['email'];
 
-                        echo '<td><form action="../AdminEntry.php" method="POST">';
+                        echo '<td><form action="../AdminEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">';
                         echo '<input type="hidden" name="emailToDelete" 
 												value="' . $customerS . '" >';
                         echo '<button type="submit" value="Delete Customer" 
@@ -150,7 +157,8 @@ if (!isset($_SESSION['email'])) {
 												<i class="fas fa-times"><h7> Delete <h7></i></button>';
                         echo '</form></td>';
 
-                        echo '<td><form action="editCustomer.php" method="POST">';
+                        echo '<td><form action="editCustomer.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">';
                         echo '<input type="hidden" name="customerToUpdate" 
 												value="' . $customerS . '" >';
                         echo '<button type="submit" value="editCustomer" 

--- a/CliniCare/AdminPage/dist/editCustomer.php
+++ b/CliniCare/AdminPage/dist/editCustomer.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -39,6 +43,7 @@ if (!isset($_SESSION['email'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -54,6 +59,7 @@ if (!isset($_SESSION['email'])) {
               </a>
               <a href="#" class="dropdown-item has-icon">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>
@@ -109,6 +115,7 @@ if (!isset($_SESSION['email'])) {
 
             <div class="card">
               <form action="../AdminEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
 
                 <div class="card-body">
                   <div class="section-title mt-0">Edit Profile</div>

--- a/CliniCare/AdminPage/dist/index.php
+++ b/CliniCare/AdminPage/dist/index.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -45,6 +49,7 @@ if (!isset($_SESSION['email'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -60,6 +65,7 @@ if (!isset($_SESSION['email'])) {
               </a>
               <a href="#" class="dropdown-item has-icon">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>

--- a/CliniCare/AdminPage/dist/paymentHistory.php
+++ b/CliniCare/AdminPage/dist/paymentHistory.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -44,6 +48,7 @@ if (!isset($_SESSION['email'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -59,6 +64,7 @@ if (!isset($_SESSION['email'])) {
               </a>
               <a href="#" class="dropdown-item has-icon">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>

--- a/CliniCare/AdminPage/dist/profile.php
+++ b/CliniCare/AdminPage/dist/profile.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -75,6 +79,7 @@ if (isset($_POST['submit'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -92,6 +97,7 @@ if (isset($_POST['submit'])) {
               </a>
               <a href="#" class="dropdown-item has-icon">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>
@@ -159,6 +165,7 @@ if (isset($_POST['submit'])) {
                     <br><br><br><br>
                     <label class="labels" style="font-size: 12px">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Edit Profile Picture</label>
                     <form action="" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                       &nbsp;&nbsp;&nbsp;<input type="file" name="file">
                       <br>
                       &nbsp;&nbsp;&nbsp;<input type="submit" name="submit">
@@ -176,6 +183,7 @@ if (isset($_POST['submit'])) {
 
                 <div class="card profile-widget">
                   <form class="form-sample" action="change-p.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                     <div class="card-header">
                       <h4>Change Password</h4>
                     </div>
@@ -220,6 +228,7 @@ if (isset($_POST['submit'])) {
               <div class="col-12 col-md-12 col-lg-7">
                 <div class="card">
                   <form method="post" class="needs-validation" action="../AdminEntry.php" novalidate="">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
 
                     <div class="card-header">
                       <h4>Edit Profile</h4>

--- a/CliniCare/AdminPage/dist/purchaseHistory.php
+++ b/CliniCare/AdminPage/dist/purchaseHistory.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -44,6 +48,7 @@ if (!isset($_SESSION['email'])) {
       <div class="navbar-bg"></div>
       <nav class="navbar navbar-expand-lg main-navbar">
         <form class="form-inline mr-auto">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
           <ul class="navbar-nav mr-3">
             <li><a href="#" data-toggle="sidebar" class="nav-link nav-link-lg"><i class="fas fa-bars"></i></a></li>
             <li><a href="#" data-toggle="search" class="nav-link nav-link-lg d-sm-none"><i class="fas fa-search"></i></a></li>
@@ -59,6 +64,7 @@ if (!isset($_SESSION['email'])) {
               </a>
               <a href="#" class="dropdown-item has-icon">
                 <form action="../../Customer/CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <button type="submit" class="dropdown-item has-icon" name="signout" id="signout" style="color:red; text-align:center">Sign Out </button>
                 </form>
               </a>

--- a/CliniCare/Customer/CustomerEntry.php
+++ b/CliniCare/Customer/CustomerEntry.php
@@ -1,5 +1,15 @@
 <?php
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    if (!isset($_POST["csrf_token"]) || !hash_equals($_SESSION["csrf_token"], $_POST["csrf_token"])) {
+        die("Invalid CSRF token");
+    }
+    unset($_SESSION["csrf_token"]);
+}
+
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;

--- a/CliniCare/Customer/CustomerHomePage/index.php
+++ b/CliniCare/Customer/CustomerHomePage/index.php
@@ -1,6 +1,10 @@
 <?php
 include "../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -98,6 +102,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../Index Pages/History/myHistory.php">View History</a></li>
               <li><a href="../Index Pages/Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>
@@ -710,6 +715,7 @@ if (!isset($_SESSION['email'])) {
 
             <div class="card-body">
               <form action="giveFeedback.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <input type="text" name="UName" placeholder="User Name" class="form-control mb-2" required>
                 <input type="email" name="Email" placeholder="Email" class="form-control mb-2" required>
                 <input type="text" name="Subject" placeholder="Subject" class="form-control mb-2" required>

--- a/CliniCare/Customer/Index Pages/Appointment/AppointmentSlot.php
+++ b/CliniCare/Customer/Index Pages/Appointment/AppointmentSlot.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -137,6 +141,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>
@@ -175,6 +180,7 @@ if (!isset($_SESSION['email'])) {
                 </div>
 
                 <form class="forms-sample" action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
 
                   <div class="row mt-3">
                     <div class="col-md-12">

--- a/CliniCare/Customer/Index Pages/History/myHistory.php
+++ b/CliniCare/Customer/Index Pages/History/myHistory.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -294,6 +298,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>

--- a/CliniCare/Customer/Index Pages/Profile/myProfile.php
+++ b/CliniCare/Customer/Index Pages/Profile/myProfile.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -140,6 +144,7 @@ if (isset($_POST['submit'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>
@@ -185,6 +190,7 @@ if (isset($_POST['submit'])) {
                   <label class="labels" style="font-size: 12px">Edit Profile Picture</label>
                   <div class="upload-btn-wrapper">
                     <form action="" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                       <input id="upload" type="file" name="file" onchange="submitImage()"><br>
                       <input id="submit" type="submit" name="submit" hidden="true">
                     </form>
@@ -203,6 +209,7 @@ if (isset($_POST['submit'])) {
                 </div>
 
                 <form class="forms-sample" action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
 
                   <div class="row mt-3">
                     <div class="col-md-12">
@@ -266,6 +273,7 @@ if (isset($_POST['submit'])) {
                 <p class="card-description"></p>
 
                 <form class="form-sample" action="change-p.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                   <div class="col-md-12">
                     <label class="label" style="font-size: 12px">Current Password</label>
                     <input type="password" class="form-control" placeholder="Password" name="op" aria-label="Username">

--- a/CliniCare/Customer/Index Pages/medicine/AcetinSachet5gTablet.php
+++ b/CliniCare/Customer/Index Pages/medicine/AcetinSachet5gTablet.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -175,6 +180,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med1" name="med1" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/AcetylcysteineSandoz20Tablet.php
+++ b/CliniCare/Customer/Index Pages/medicine/AcetylcysteineSandoz20Tablet.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med3" name="med3" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/Actimax500Tablet.php
+++ b/CliniCare/Customer/Index Pages/medicine/Actimax500Tablet.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med6" name="med6" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/Acugesic50mgTablet.php
+++ b/CliniCare/Customer/Index Pages/medicine/Acugesic50mgTablet.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med4" name="med4" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/Alleryl5mlSyrup.php
+++ b/CliniCare/Customer/Index Pages/medicine/Alleryl5mlSyrup.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med11" name="med11" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/AnoroEllipta.php
+++ b/CliniCare/Customer/Index Pages/medicine/AnoroEllipta.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med12" name="med12" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/Apo-Sumatriptan50mgTablet.php
+++ b/CliniCare/Customer/Index Pages/medicine/Apo-Sumatriptan50mgTablet.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med5" name="med5" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/AppetonFolicAcidTablet.php
+++ b/CliniCare/Customer/Index Pages/medicine/AppetonFolicAcidTablet.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -177,6 +182,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med7" name="med7" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/Aspira10mgTablet.php
+++ b/CliniCare/Customer/Index Pages/medicine/Aspira10mgTablet.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med10" name="med10" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/BlackmoresProceiveCare.php
+++ b/CliniCare/Customer/Index Pages/medicine/BlackmoresProceiveCare.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -177,6 +182,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med9" name="med9" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/BreacolCoughSyrup500ml.php
+++ b/CliniCare/Customer/Index Pages/medicine/BreacolCoughSyrup500ml.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med2" name="med2" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/CellLabsProbiDefendum.php
+++ b/CliniCare/Customer/Index Pages/medicine/CellLabsProbiDefendum.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -134,6 +138,7 @@ if (!isset($_SESSION['email'])) {
                             <li><a href="../History/myHistory.php">View History</a></li>
                             <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
                             <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                 <li>
                                     <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                                             Sign Out</button></a>
@@ -176,6 +181,7 @@ if (!isset($_SESSION['email'])) {
                                     </h2>
 
                                     <form action="CartEntry.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                                         <button type="submit" id="med8" name="med8" class="btn btn-primary" style="font-size:17px; color:white; ">
                                             Add to cart
                                         </button>

--- a/CliniCare/Customer/Index Pages/medicine/MedicineCatalogueUser.php
+++ b/CliniCare/Customer/Index Pages/medicine/MedicineCatalogueUser.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -101,6 +105,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>

--- a/CliniCare/Customer/Index Pages/medicine/viewCart.php
+++ b/CliniCare/Customer/Index Pages/medicine/viewCart.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -373,6 +377,7 @@ if (!isset($_SESSION['email'])) {
                   
                   <div class='col'> 
                   <form action='CartEntry.php' method='POST'>
+                  <input type='hidden' name='csrf_token' value='" . $_SESSION['csrf_token'] . "'>
                   <button type='submit' href='#' style='padding: 0 2vh' id='-' name='-' style='background-color: Transparent;' >-</button>
                   <input type='hidden' name='productIDToMinus' value='$productID'>             
                   <a href='#' class='border' style='padding: 0 2vh;'>" . $quantity . "</a> 
@@ -405,6 +410,7 @@ if (!isset($_SESSION['email'])) {
                         </div>
         
                           <form action='GenerateGatewayPaymentCall.php' method='POST'>
+                            <input type='hidden' name='csrf_token' value='" . $_SESSION['csrf_token'] . "'>
 
                             <h5><b>Details</b></h5>
                             <hr>

--- a/CliniCare/Customer/Index Pages/services/checkup.php
+++ b/CliniCare/Customer/Index Pages/services/checkup.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -104,6 +108,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>

--- a/CliniCare/Customer/Index Pages/services/covid.php
+++ b/CliniCare/Customer/Index Pages/services/covid.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -104,6 +108,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>

--- a/CliniCare/Customer/Index Pages/services/momBaby.php
+++ b/CliniCare/Customer/Index Pages/services/momBaby.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -104,6 +108,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>

--- a/CliniCare/Customer/Index Pages/services/pharmacy.php
+++ b/CliniCare/Customer/Index Pages/services/pharmacy.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -104,6 +108,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>

--- a/CliniCare/Customer/Index Pages/services/primaryCare.php
+++ b/CliniCare/Customer/Index Pages/services/primaryCare.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -104,6 +108,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>

--- a/CliniCare/Customer/Index Pages/services/smoking.php
+++ b/CliniCare/Customer/Index Pages/services/smoking.php
@@ -1,6 +1,10 @@
 <?php
 include "../../db_conn.php";
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 $email = $_SESSION['email'];
 $query = mysqli_query($con, "SELECT * FROM customer WHERE email='$email' ");
 $row = mysqli_fetch_array($query);
@@ -105,6 +109,7 @@ if (!isset($_SESSION['email'])) {
               <li><a href="../History/myHistory.php">View History</a></li>
               <li><a href="../Appointment/AppointmentSlot.php">Make an Appointment</a></li>
               <form action="../../CustomerEntry.php" method="POST">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <li>
                   <a><button type="submit" href="#" style="background: transparent; border: none; padding: 0; margin:0; position:relative; color:red" name="signout">
                       Sign Out</button></a>

--- a/CliniCare/Customer/Sign In Page/Sign In/forgotPassword.php
+++ b/CliniCare/Customer/Sign In Page/Sign In/forgotPassword.php
@@ -1,3 +1,9 @@
+<?php
+session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -32,6 +38,7 @@
                     <div class="signin-form">
                         <h2 class="form-title">Forgot Password</h2>
                         <form method="POST" class="signin" id="login-form" action="../../CustomerEntry.php">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                             <div class="form-group">
                                 <label for="your_name"><i class="zmdi zmdi-account material-icons-name"></i></label>
                                 <input type="text" name="email" id="email" placeholder="Email Address" />

--- a/CliniCare/Customer/Sign In Page/Sign In/resetPassword.php
+++ b/CliniCare/Customer/Sign In Page/Sign In/resetPassword.php
@@ -1,5 +1,9 @@
 <?php
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 if (isset($_GET['vkey'])) {
     $_SESSION['resetVkey'] = $_GET['vkey'];
 }
@@ -39,6 +43,7 @@ if (isset($_GET['vkey'])) {
                     <div class="signin-form">
                         <h2 class="form-title">Reset Password</h2>
                         <form method="POST" class="signin" id="login-form" action="../../CustomerEntry.php">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                             <div class="form-group">
                                 <label for="your_pass"><i class="zmdi zmdi-lock"></i></label>
                                 <input type="password" name="pwd" placeholder="New Password" />

--- a/CliniCare/Customer/Sign In Page/Sign In/signin.php
+++ b/CliniCare/Customer/Sign In Page/Sign In/signin.php
@@ -1,5 +1,9 @@
 <?php
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 if (isset($_SESSION['email'])) {
     $_SESSION['email'] = $email;
 }
@@ -42,6 +46,7 @@ if (isset($_SESSION['email'])) {
                     <div class="signin-form">
                         <h2 class="form-title">Sign In</h2>
                         <form method="POST" class="signin" id="login-form" action="../../CustomerEntry.php">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                             <div class="form-group">
                                 <label for="your_name"><i class="zmdi zmdi-account material-icons-name"></i></label>
                                 <input type="text" name="email" id="email" placeholder="Email Address" required>

--- a/CliniCare/Customer/Sign Up Page/Sign Up/signup.php
+++ b/CliniCare/Customer/Sign Up Page/Sign Up/signup.php
@@ -1,3 +1,9 @@
+<?php
+session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -28,6 +34,7 @@
                     <div class="signup-form">
                         <h2 class="form-title">Sign up</h2>
                         <form method="POST" class="signup" id="register-form" action="../../CustomerEntry.php">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                             <div class="form-group">
                                 <label for="name"><i class="zmdi zmdi-account material-icons-name"></i></label>
                                 <input type="text" name="name" id="name" placeholder="Your Name" required>

--- a/CliniCare/index.php
+++ b/CliniCare/index.php
@@ -1,5 +1,9 @@
 <?php
 session_start();
+if (empty($_SESSION["csrf_token"])) {
+    $_SESSION["csrf_token"] = bin2hex(random_bytes(32));
+}
+
 if (isset($_SESSION['email'])) {
   header("Location: Customer/CustomerHomePage/index.php");
 }
@@ -679,6 +683,7 @@ if (isset($_SESSION['email'])) {
 
             <div class="card-body">
               <form action="giveFeedback.php" method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo $_SESSION["csrf_token"]; ?>">
                 <input type="text" name="UName" placeholder="User Name" class="form-control mb-2" required>
                 <input type="email" name="Email" placeholder="Email" class="form-control mb-2" required>
                 <input type="text" name="Subject" placeholder="Subject" class="form-control mb-2" required>


### PR DESCRIPTION
## Summary
- Add one-time CSRF token generation on session start
- Embed CSRF token field in application forms
- Validate and invalidate tokens in AdminEntry.php and CustomerEntry.php

## Testing
- `php -l CliniCare/AdminPage/AdminEntry.php`
- `php -l CliniCare/Customer/CustomerEntry.php`
- `git status --porcelain | sed -e 's/^.. //' | tr -d '"' | while IFS= read -r file; do php -l "$file"; done`


------
https://chatgpt.com/codex/tasks/task_e_68aff3308e30832083b25acc30b2a999