### PR TITLE
fix: compute Database.php path relative to file

### DIFF
--- a/CliniCare/Customer/CustomerHomePage/index.php
+++ b/CliniCare/Customer/CustomerHomePage/index.php
@@ -1,5 +1,5 @@
 <?php
-require_once $_SERVER['DOCUMENT_ROOT'] . '/app/Core/Database.php';
+require_once __DIR__ . '/../../app/Core/Database.php';
 $con = Database::getConnection();
 session_start();
 $email = $_SESSION['email'];


### PR DESCRIPTION
## Summary
- load Database.php relative to CustomerHomePage so installs under subdirectories resolve correctly

## Testing
- `git diff --name-only --diff-filter=AM HEAD~1..HEAD | while IFS= read -r file; do php -l "$file"; done`


------
https://chatgpt.com/codex/tasks/task_e_68ba442461e88320b3281a781d0e8600