### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: CliniCare/Customer/PHPMailer
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies, run PHP_CodeSniffer, and execute PHPUnit
- run PHP tools in the CliniCare/Customer/PHPMailer directory to avoid missing composer.json errors

## Testing
- `pip install pyyaml`
- `python - <<'PY'
import yaml,sys
with open('.github/workflows/ci.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `cd CliniCare/Customer/PHPMailer && composer install --prefer-dist --no-progress --no-suggest`
- `vendor/bin/phpcs` *(fails: You must supply at least one file or directory to process)*
- `vendor/bin/phpunit` *(shows usage information; no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ba454987108320bdcd0a733f9cbee6