### PR TITLE
fix: load Database.php relative to script

### DIFF
--- a/CliniCare/Customer/CustomerHomePage/index.php
+++ b/CliniCare/Customer/CustomerHomePage/index.php
@@ -1,5 +1,5 @@
 <?php
-require_once $_SERVER['DOCUMENT_ROOT'] . '/app/Core/Database.php';
+require_once __DIR__ . '/../../app/Core/Database.php';
 $con = Database::getConnection();
 session_start();
 $email = $_SESSION['email'];


### PR DESCRIPTION
## Summary
- load Database.php relative to current file to support subdirectory installs

## Testing
- `git diff --name-only --diff-filter=AM | while IFS= read -r file; do php -l "$file"; done`


------
https://chatgpt.com/codex/tasks/task_e_68ba43fa49e883208af1c84adc3c6228